### PR TITLE
Organized Filters

### DIFF
--- a/CareTogether.Report/definition/pages/03622d788c359b5e7432/page.json
+++ b/CareTogether.Report/definition/pages/03622d788c359b5e7432/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "03622d788c359b5e7432",
   "displayName": "Approvals History",
   "displayOption": "FitToPage",
@@ -20,62 +20,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "DateAdd": {
-                              "Expression": {
-                                "Now": {}
-                              },
-                              "Amount": 1,
-                              "TimeUnit": 0
-                            }
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 2
-                        }
-                      },
-                      "TimeUnit": 0
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "Now": {}
-                      },
-                      "TimeUnit": 0
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       },
       {

--- a/CareTogether.Report/definition/pages/101a4b085e432a0c869a/page.json
+++ b/CareTogether.Report/definition/pages/101a4b085e432a0c869a/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "101a4b085e432a0c869a",
   "displayName": "Churches",
   "displayOption": "FitToPage",
@@ -21,62 +21,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       },
       {

--- a/CareTogether.Report/definition/pages/148b7f02dc4c0dd0b432/page.json
+++ b/CareTogether.Report/definition/pages/148b7f02dc4c0dd0b432/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "148b7f02dc4c0dd0b432",
   "displayName": "Childcare",
   "displayOption": "FitToPage",
@@ -21,62 +21,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       },
       {

--- a/CareTogether.Report/definition/pages/37baafef208e0e3d0ee7/page.json
+++ b/CareTogether.Report/definition/pages/37baafef208e0e3d0ee7/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "37baafef208e0e3d0ee7",
   "displayName": "Arrangements",
   "displayOption": "FitToPage",
@@ -20,62 +20,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "DateAdd": {
-                              "Expression": {
-                                "Now": {}
-                              },
-                              "Amount": 1,
-                              "TimeUnit": 0
-                            }
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 1
-                        }
-                      },
-                      "TimeUnit": 0
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "Now": {}
-                      },
-                      "TimeUnit": 0
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       }
     ]

--- a/CareTogether.Report/definition/pages/3998b4c8362c11ddd270/page.json
+++ b/CareTogether.Report/definition/pages/3998b4c8362c11ddd270/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "3998b4c8362c11ddd270",
   "displayName": "Referrals",
   "displayOption": "FitToPage",
@@ -20,62 +20,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       }
     ]

--- a/CareTogether.Report/definition/pages/7ff2cfc14b864ab32dab/page.json
+++ b/CareTogether.Report/definition/pages/7ff2cfc14b864ab32dab/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "7ff2cfc14b864ab32dab",
   "displayName": "Engagement",
   "displayOption": "FitToPage",
@@ -21,62 +21,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "DateAdd": {
-                              "Expression": {
-                                "Now": {}
-                              },
-                              "Amount": 1,
-                              "TimeUnit": 0
-                            }
-                          },
-                          "Amount": -100,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 0
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "Now": {}
-                      },
-                      "TimeUnit": 0
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       },
       {

--- a/CareTogether.Report/definition/pages/96791911d9aa80a413e8/visuals/1ba4ddbe1a8a2c669596/visual.json
+++ b/CareTogether.Report/definition/pages/96791911d9aa80a413e8/visuals/1ba4ddbe1a8a2c669596/visual.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/1.7.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.0.0/schema.json",
   "name": "1ba4ddbe1a8a2c669596",
   "position": {
     "x": 10.443686006825939,
@@ -377,5 +377,23 @@
       ]
     },
     "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "68d230d62b10651d29c8",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Export Contacts"
+              }
+            },
+            "Property": "Entity Type"
+          }
+        },
+        "type": "Categorical"
+      }
+    ]
   }
 }

--- a/CareTogether.Report/definition/pages/96791911d9aa80a413e8/visuals/e3a4a3818596e3008831/visual.json
+++ b/CareTogether.Report/definition/pages/96791911d9aa80a413e8/visuals/e3a4a3818596e3008831/visual.json
@@ -17,20 +17,6 @@
           "projections": [
             {
               "field": {
-                "Column": {
-                  "Expression": {
-                    "SourceRef": {
-                      "Entity": "Entity"
-                    }
-                  },
-                  "Property": "RLS Key"
-                }
-              },
-              "queryRef": "Entity.RLS Key",
-              "nativeQueryRef": "RLS Key"
-            },
-            {
-              "field": {
                 "Measure": {
                   "Expression": {
                     "SourceRef": {
@@ -820,8 +806,40 @@
         "isLockedInViewMode": true
       },
       {
-        "name": "97533da7124c7c76f41c",
+        "name": "ccafc08ecbb0ab24d70d",
         "ordinal": 14,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Entity"
+              }
+            },
+            "Property": "Participation Type"
+          }
+        },
+        "type": "Categorical",
+        "howCreated": "User",
+        "isLockedInViewMode": true,
+        "objects": {
+          "general": [
+            {
+              "properties": {
+                "isInvertedSelectionMode": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "true"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "97533da7124c7c76f41c",
+        "ordinal": 15,
         "field": {
           "Measure": {
             "Expression": {
@@ -873,20 +891,6 @@
         },
         "howCreated": "User",
         "isHiddenInViewMode": true
-      },
-      {
-        "name": "ae16ea4b138543268b00",
-        "field": {
-          "Column": {
-            "Expression": {
-              "SourceRef": {
-                "Entity": "Entity"
-              }
-            },
-            "Property": "RLS Key"
-          }
-        },
-        "type": "Categorical"
       }
     ],
     "filterSortOrder": "Custom"

--- a/CareTogether.Report/definition/pages/b86606d8cc618ca89105/page.json
+++ b/CareTogether.Report/definition/pages/b86606d8cc618ca89105/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "b86606d8cc618ca89105",
   "displayName": "Approvals",
   "displayOption": "FitToPage",
@@ -21,62 +21,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       }
     ],

--- a/CareTogether.Report/definition/pages/d08ff20b71001be16c90/page.json
+++ b/CareTogether.Report/definition/pages/d08ff20b71001be16c90/page.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.3.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.4.0/schema.json",
   "name": "d08ff20b71001be16c90",
   "displayName": "Impact",
   "displayOption": "FitToPage",
@@ -20,62 +20,6 @@
           }
         },
         "type": "RelativeDate",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "d",
-              "Entity": "Date",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "Between": {
-                  "Expression": {
-                    "Column": {
-                      "Expression": {
-                        "SourceRef": {
-                          "Source": "d"
-                        }
-                      },
-                      "Property": "Date"
-                    }
-                  },
-                  "LowerBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  },
-                  "UpperBound": {
-                    "DateSpan": {
-                      "Expression": {
-                        "DateAdd": {
-                          "Expression": {
-                            "Now": {}
-                          },
-                          "Amount": -1,
-                          "TimeUnit": 3
-                        }
-                      },
-                      "TimeUnit": 3
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        },
         "howCreated": "User"
       },
       {

--- a/CareTogether.Report/definition/pages/pages.json
+++ b/CareTogether.Report/definition/pages/pages.json
@@ -13,5 +13,5 @@
     "ReportSectiondde1dd56e86a6be0bd57",
     "e3e436ecd75be754ee24"
   ],
-  "activePageName": "96791911d9aa80a413e8"
+  "activePageName": "d08ff20b71001be16c90"
 }

--- a/CareTogether.Report/definition/report.json
+++ b/CareTogether.Report/definition/report.json
@@ -14,6 +14,77 @@
   },
   "layoutOptimization": "None",
   "filterConfig": {
+    "filters": [
+      {
+        "name": "837e9567fc9ca18ecf4e",
+        "ordinal": 0,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Date"
+              }
+            },
+            "Property": "Date"
+          }
+        },
+        "type": "RelativeDate",
+        "filter": {
+          "Version": 2,
+          "From": [
+            {
+              "Name": "d",
+              "Entity": "Date",
+              "Type": 0
+            }
+          ],
+          "Where": [
+            {
+              "Condition": {
+                "Comparison": {
+                  "ComparisonKind": 0,
+                  "Left": {
+                    "Column": {
+                      "Expression": {
+                        "SourceRef": {
+                          "Source": "d"
+                        }
+                      },
+                      "Property": "Date"
+                    }
+                  },
+                  "Right": {
+                    "DateSpan": {
+                      "Expression": {
+                        "Now": {}
+                      },
+                      "TimeUnit": 3
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "howCreated": "User"
+      },
+      {
+        "name": "c043e3c3f8b1773d0da4",
+        "ordinal": 1,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Location"
+              }
+            },
+            "Property": "Location"
+          }
+        },
+        "type": "Categorical",
+        "howCreated": "User"
+      }
+    ],
     "filterSortOrder": "Custom"
   },
   "objects": {

--- a/CareTogether.SemanticModel/definition/model.tmdl
+++ b/CareTogether.SemanticModel/definition/model.tmdl
@@ -33,7 +33,7 @@ annotation PBI_QueryOrder = ["Community","Role","OData Live","Production","Refer
 
 annotation __PBI_TimeIntelligenceEnabled = 1
 
-annotation PBIDesktopVersion = 2.143.878.0 (25.05)+b20aa3b866ec1b70879135a4e60e4b1301c75b21
+annotation PBIDesktopVersion = 2.143.1204.0 (25.05)+23c84aace645781dd62b8a26eb0418c7e6a84b72
 
 annotation PBI_ProTooling = ["CalcGroup","DevMode","DaxQueryView_Desktop"]
 

--- a/CareTogether.SemanticModel/definition/tables/Entity.tmdl
+++ b/CareTogether.SemanticModel/definition/tables/Entity.tmdl
@@ -447,6 +447,7 @@ table Entity
 
 	column PersonId
 		dataType: string
+		displayFolder: _columns
 		lineageTag: ce8a1026-5955-4183-a8dd-91c131b60422
 		summarizeBy: none
 		sourceColumn: PersonId
@@ -455,6 +456,7 @@ table Entity
 
 	column OrganizationId
 		dataType: string
+		displayFolder: _columns
 		lineageTag: c2020579-1e5b-4384-8d73-c63db2883fb3
 		summarizeBy: none
 		sourceColumn: OrganizationId
@@ -463,6 +465,7 @@ table Entity
 
 	column LocationId
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 1cd5ece6-3e22-4e4d-a795-478aa93be465
 		summarizeBy: none
 		sourceColumn: LocationId
@@ -471,6 +474,7 @@ table Entity
 
 	column 'RLS Key'
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 087909ae-97c5-4c52-b7d3-0a256af54a96
 		summarizeBy: none
 		sourceColumn: RLS Key
@@ -479,6 +483,7 @@ table Entity
 
 	column 'Family Name'
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 74940fab-8358-4136-a3ed-8e8dbb227c74
 		summarizeBy: none
 		sourceColumn: Family Name
@@ -487,6 +492,7 @@ table Entity
 
 	column Email
 		dataType: string
+		displayFolder: _columns
 		lineageTag: c2808eba-a9ab-4a86-8eac-afe5be7fe2ad
 		summarizeBy: none
 		sourceColumn: Email
@@ -495,6 +501,7 @@ table Entity
 
 	column 'Phone Number'
 		dataType: string
+		displayFolder: _columns
 		lineageTag: fde2e83a-ee9f-4fed-aa17-6c29e5b9299a
 		summarizeBy: none
 		sourceColumn: Phone Number
@@ -503,6 +510,7 @@ table Entity
 
 	column 'Address Line 1'
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 38500f73-01a0-4d69-bf89-53aa8173d01f
 		summarizeBy: none
 		sourceColumn: Address Line 1
@@ -511,6 +519,7 @@ table Entity
 
 	column 'Address Line 2'
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 55a68ebf-4b08-4323-9f1b-ac3afc65629e
 		summarizeBy: none
 		sourceColumn: Address Line 2
@@ -519,6 +528,7 @@ table Entity
 
 	column City
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 0873ce1f-73e9-4a4c-94b8-031fcb88f04a
 		summarizeBy: none
 		sourceColumn: City
@@ -527,6 +537,7 @@ table Entity
 
 	column County
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 26222d31-db01-4684-9dd6-a138835ab0bf
 		summarizeBy: none
 		sourceColumn: County
@@ -535,6 +546,7 @@ table Entity
 
 	column State
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 3bad9943-09af-45ab-bfc3-8917498f84cd
 		summarizeBy: none
 		sourceColumn: State
@@ -543,6 +555,7 @@ table Entity
 
 	column PostalCode
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 4bcb8b53-8713-4a37-999f-5b70e43ad398
 		summarizeBy: none
 		sourceColumn: PostalCode
@@ -551,6 +564,7 @@ table Entity
 
 	column HomeChurch
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 03c5c23e-17a6-4b06-94d5-f94a6c7ba11a
 		summarizeBy: none
 		sourceColumn: HomeChurch
@@ -559,6 +573,7 @@ table Entity
 
 	column 'Full Name'
 		dataType: string
+		displayFolder: _columns
 		lineageTag: 0fdf0d38-48ce-473f-8199-67e2ed60bf01
 		summarizeBy: none
 		sourceColumn: Full Name


### PR DESCRIPTION
The following changes have been made:

- All page-level filters have been cleared.
- Added the Location filter at the report level (with no option selected).
- Added a Date filter at the report level (with the current year selected).
- Added the Participation Type filter to the contact data export table.

**P.S**. – It's important to inform the user that they need to click on the table to view the applicable filters before exporting the data.