### PR TITLE
Including a security filter in the Approvals Tracker to remove empty …

### DIFF
--- a/CareTogether.Report/definition/pages/03622d788c359b5e7432/visuals/bb53773b627777712a28/visual.json
+++ b/CareTogether.Report/definition/pages/03622d788c359b5e7432/visuals/bb53773b627777712a28/visual.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.1.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.5.0/schema.json",
   "name": "bb53773b627777712a28",
   "position": {
     "x": 11,
@@ -870,5 +870,141 @@
       ]
     },
     "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "6ce40ab1690be64050e8",
+        "ordinal": 0,
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Individual Role Approvals"
+              }
+            },
+            "Property": "Individual Approval Tracker"
+          }
+        },
+        "type": "Advanced",
+        "filter": {
+          "Version": 2,
+          "From": [
+            {
+              "Name": "i",
+              "Entity": "Individual Role Approvals",
+              "Type": 0
+            }
+          ],
+          "Where": [
+            {
+              "Condition": {
+                "Not": {
+                  "Expression": {
+                    "Comparison": {
+                      "ComparisonKind": 0,
+                      "Left": {
+                        "Measure": {
+                          "Expression": {
+                            "SourceRef": {
+                              "Source": "i"
+                            }
+                          },
+                          "Property": "Individual Approval Tracker"
+                        }
+                      },
+                      "Right": {
+                        "Literal": {
+                          "Value": "null"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "isHiddenInViewMode": true,
+        "isLockedInViewMode": true
+      },
+      {
+        "name": "c5b2e311058130537469",
+        "ordinal": 1,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Approval Type"
+              }
+            },
+            "Property": "Approval Type"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "df60e700c001148a605b",
+        "ordinal": 2,
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Individual Role Approvals"
+              }
+            },
+            "Property": "Individual Approval Tracker"
+          }
+        },
+        "type": "Advanced",
+        "howCreated": "User"
+      },
+      {
+        "name": "319a322151d622abbb08",
+        "ordinal": 3,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Individual Role Approvals"
+              }
+            },
+            "Property": "Person Name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "a3a2f990169989a020d0",
+        "ordinal": 4,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Role"
+              }
+            },
+            "Property": "Role Name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "ec3df96665eecec080a3",
+        "ordinal": 5,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Approval Status"
+              }
+            },
+            "Property": "Status"
+          }
+        },
+        "type": "Categorical"
+      }
+    ],
+    "filterSortOrder": "Custom"
   }
 }

--- a/CareTogether.Report/definition/pages/03622d788c359b5e7432/visuals/d6084660d102c3617329/visual.json
+++ b/CareTogether.Report/definition/pages/03622d788c359b5e7432/visuals/d6084660d102c3617329/visual.json
@@ -147,6 +147,18 @@
             "queryRefs": [
               "Family Role Approvals.Entity Name"
             ],
+            "identityKeys": [
+              {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Family Role Approvals"
+                    }
+                  },
+                  "Property": "Family Name"
+                }
+              }
+            ],
             "isPinned": true
           },
           {
@@ -893,49 +905,63 @@
   "filterConfig": {
     "filters": [
       {
-        "name": "75e07629fa391086d7b0",
+        "name": "1e953a2d10deab77d06a",
+        "ordinal": 0,
         "field": {
-          "Column": {
-            "Expression": {
-              "SourceRef": {
-                "Entity": "Approval Status"
-              }
-            },
-            "Property": "Status"
-          }
-        },
-        "type": "Categorical"
-      },
-      {
-        "name": "f5d07b2e2838d828a4cb",
-        "field": {
-          "Column": {
-            "Expression": {
-              "SourceRef": {
-                "Entity": "Role"
-              }
-            },
-            "Property": "Role Name"
-          }
-        },
-        "type": "Categorical"
-      },
-      {
-        "name": "edd4f3c48b75de26d40e",
-        "field": {
-          "Column": {
+          "Measure": {
             "Expression": {
               "SourceRef": {
                 "Entity": "Family Role Approvals"
               }
             },
-            "Property": "Family Name"
+            "Property": "Family Approval Tracker"
           }
         },
-        "type": "Categorical"
+        "type": "Advanced",
+        "filter": {
+          "Version": 2,
+          "From": [
+            {
+              "Name": "f",
+              "Entity": "Family Role Approvals",
+              "Type": 0
+            }
+          ],
+          "Where": [
+            {
+              "Condition": {
+                "Not": {
+                  "Expression": {
+                    "Comparison": {
+                      "ComparisonKind": 0,
+                      "Left": {
+                        "Measure": {
+                          "Expression": {
+                            "SourceRef": {
+                              "Source": "f"
+                            }
+                          },
+                          "Property": "Family Approval Tracker"
+                        }
+                      },
+                      "Right": {
+                        "Literal": {
+                          "Value": "null"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "isHiddenInViewMode": true,
+        "isLockedInViewMode": true
       },
       {
         "name": "5454a515ba402e2d9c48",
+        "ordinal": 1,
         "field": {
           "Column": {
             "Expression": {
@@ -950,6 +976,7 @@
       },
       {
         "name": "19b5f7ff94ba3220b409",
+        "ordinal": 2,
         "field": {
           "Measure": {
             "Expression": {
@@ -960,8 +987,55 @@
             "Property": "Family Approval Tracker"
           }
         },
-        "type": "Advanced"
+        "type": "Advanced",
+        "howCreated": "User"
+      },
+      {
+        "name": "edd4f3c48b75de26d40e",
+        "ordinal": 3,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Family Role Approvals"
+              }
+            },
+            "Property": "Family Name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "f5d07b2e2838d828a4cb",
+        "ordinal": 4,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Role"
+              }
+            },
+            "Property": "Role Name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "75e07629fa391086d7b0",
+        "ordinal": 5,
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Approval Status"
+              }
+            },
+            "Property": "Status"
+          }
+        },
+        "type": "Categorical"
       }
-    ]
+    ],
+    "filterSortOrder": "Custom"
   }
 }

--- a/CareTogether.Report/definition/pages/pages.json
+++ b/CareTogether.Report/definition/pages/pages.json
@@ -13,5 +13,5 @@
     "ReportSectiondde1dd56e86a6be0bd57",
     "e3e436ecd75be754ee24"
   ],
-  "activePageName": "03622d788c359b5e7432"
+  "activePageName": "d08ff20b71001be16c90"
 }


### PR DESCRIPTION
To improve the user experience, a hidden filter has been added that removes rows for roles where no data is available.
This will be useful when exporting data to Excel, as it prevents unnecessary expansion of the dataset.